### PR TITLE
Bugfix - header background image

### DIFF
--- a/src/scss/blocks/_header.scss
+++ b/src/scss/blocks/_header.scss
@@ -1,8 +1,7 @@
 .site-header {
   background-color: get-color('primary');
-  background-image: url("images/logo/damask-floral-overlay.png");
+  background-image: url("/images/logo/damask-floral-overlay.png");
   background-size: 624px 578px;
   padding-bottom: get-size('600');
   padding-top: get-size('600');
-
 }


### PR DESCRIPTION
Currently the background image only shows on the root homepage. Any other page is trying to locate the file relative to the permalink instead of root path. This fixes to locate the image folder from the root path.