### PR TITLE
Fixing bullseye styling

### DIFF
--- a/src/scss/cv.scss
+++ b/src/scss/cv.scss
@@ -19,7 +19,6 @@ dl, section {
 }
 
 dt, dd, h2, li {
-  align-items: center;
   display: flex;
 
   > * {
@@ -70,6 +69,7 @@ dd {
   &.outline {
     border: 1px solid get-color(secondary);
     margin-left: 0;
+    margin-top: 0.7rem;
 
     &::before {
       background-color: get-color(light);
@@ -90,6 +90,7 @@ dd {
     display: inline-block;
     margin-top: 0.3rem;
     margin-left: 0;
+    margin-top: 1.1rem;
     padding: 0;
   }
 }


### PR DESCRIPTION
Currently, the bullseye styling using flexbox and `align-items` to centre the bullseye with the text.

This doesn't work where the text wraps onto multiple lines. This PR fixes alignment so that the bullseye is aligned with the top line of text.

Closes #44 