### PR TITLE
Fix blogpost fonts

### DIFF
--- a/src/scss/_fonts.scss
+++ b/src/scss/_fonts.scss
@@ -2,8 +2,8 @@
 
 @font-face {
   font-family: 'roboto_monoregular';
-  src: url('../fonts/robotomono-variablefont_wght-webfont.woff2') format('woff2'),
-       url('../fonts/robotomono-variablefont_wght-webfont.woff') format('woff');
+  src: url('/fonts/robotomono-variablefont_wght-webfont.woff2') format('woff2'),
+       url('/fonts/robotomono-variablefont_wght-webfont.woff') format('woff');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -11,8 +11,8 @@
 
 @font-face {
   font-family: 'robotolight';
-  src: url('../fonts/roboto-light-webfont.woff2') format('woff2'),
-       url('../fonts/roboto-light-webfont.woff') format('woff');
+  src: url('/fonts/roboto-light-webfont.woff2') format('woff2'),
+       url('/fonts/roboto-light-webfont.woff') format('woff');
 
   font-weight: 300;
   font-style: normal;


### PR DESCRIPTION
The fonts url was incorrectly building relative to the page being rendered rather than `root`. This caused the individual blogposts to use the fallback system font stack because these files are 1 level deep and therefore could not find the correct path for the self-hosted fonts.