### PR TITLE
Add post date

### DIFF
--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -12,7 +12,7 @@
   <article class="post">
     {% include "partials/page-title.html" %}
     {% include "partials/tags.html" %}
-    {{ date | dateFilter("full") }}
+    <div class="panel wrapper">{{ date | dateFilter("full") }}</div>
 
     <div class="flow panel wrapper">
       {{ content | safe }}

--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -12,6 +12,8 @@
   <article class="post">
     {% include "partials/page-title.html" %}
     {% include "partials/tags.html" %}
+    {{ date | dateFilter("full") }}
+
     <div class="flow panel wrapper">
       {{ content | safe }}
     <div>

--- a/src/filters/date-filter.js
+++ b/src/filters/date-filter.js
@@ -1,11 +1,13 @@
 const format = require('date-fns/format');
 const parseISO = require('date-fns/parseISO');
 
-module.exports = date => {
-  if (date === "current") {
-    return date;
-  } else {
-    const dateObject = parseISO(date);
-    return format(dateObject, "MMM yyyy");
-  }
+// defaults to short date if no variant provided.
+// @variant "short" | "full"
+
+module.exports = (date, variant = "short") => {
+  if (date === "current") return date;
+
+  const dateObject = parseISO(date);
+  if (variant === "full") return format(dateObject, "d MMM yyyy");
+  return format(dateObject, "MMM yyyy");
 };


### PR DESCRIPTION
This extends the date filter to provide a second variant - the "full" date format which is needed for the blog section.