### PR TITLE
Extending markdown

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,7 @@
 const dateFilter = require('./src/filters/date-filter.js');
+const mdIt = require('markdown-it');
+const mdDeflist = require('markdown-it-deflist');
+const mdAttrs = require('markdown-it-attrs');
 
 module.exports = (config) => {
   // Set directories to pass through to the dist folder
@@ -37,6 +40,21 @@ module.exports = (config) => {
   });
 
   config.setUseGitIgnore(false);
+
+  // customise and extend markdown
+  // mdAttr - add ids and classes
+  // mdDefList - create description lists
+  const options = {
+    html: true
+  }
+
+  const markdownLib = mdIt(options)
+    .use(mdAttrs, {
+      allowedAttributes: ['class', 'id', /^aria.*$/, ]
+    })
+    .use(mdDeflist);
+
+  config.setLibrary('md', markdownLib);
 
   return {
     markdownTemplateEngine: "njk",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "gulp-imagemin": "^7.1.0",
     "gulp-sass": "^4.1.0",
     "html-minifier": "^4.0.0",
+    "markdown-it": "^12.0.4",
+    "markdown-it-attrs": "^3.0.3",
+    "markdown-it-deflist": "^2.1.0",
     "sass": "^1.27.0"
   },
   "scripts": {

--- a/src/posts/lessons-learnt-tech-job-hunting-women-returner-2017.md
+++ b/src/posts/lessons-learnt-tech-job-hunting-women-returner-2017.md
@@ -18,9 +18,7 @@ I was really pleased to kiss goodbye to 2017. Having started job hunting back in
 
 My teenage kids don’t need me at home now, I’m ready and excited to be making my entrance back into the workforce. I may have been nurturing my boys but I still kept working throughout.
 
-<p class="pullquote repeated" aria-hidden="true">
-  It’s been the most soul destroying, confidence sucking past 8 months I’ve ever had to endure.
-</p>
+It’s been the most soul destroying, confidence sucking past 8 months I’ve ever had to endure. {.pullquote .repeated aria-hidden=true}
 
 I started out full of optimism, with awards and industry recognition under my belt to validate the work I’ve done during my time remote working. I’ve continually updated my skills through a mix of online learning, classroom based learning and on-the-job experience. Together with two friends, I’ve created a food tech startup and stepped up to the role of technical co-founder. I still continue to work on this greenfield project which has already gained attention.
 
@@ -48,9 +46,8 @@ I’ve learnt that there are some really bad recruiters out there who seem to th
 
 The most common _thanks but no thanks, we won’t be taking your application forward_ conversation is that a company is looking for someone who can hit the ground running. I’ve found that comment interesting enough to look it up in the oxford dictionary.
 
-Definition of hit the ground running:
-
-Start something and proceed at a fast pace with great enthusiasm.
+<dfn>Hit the ground running</dfn>
+: Start something and proceed at a fast pace with great enthusiasm.
 
 Hello? I think what they really mean to say is that sadly it seems that the tech industry has a much wider problem in general, there is a real shortage of senior tech talent. The knock on effect is that junior roles generally require at least ‘three years plus’ experience and an unrealistic sound working knowledge of a whole heap of technologies and frameworks. There’s very little manpower available to support the intake of more junior positions, so where will the senior developers of tomorrow come from? I now realise how wrong I was when I originally wrote my piece for the Guardian. The tech industry is great if you are carving your own path, but try breaking into an employed role and it’s a different story. I know I’m not the only one banging on doors and this isn’t a gender issue, these doors just aren’t opening for anyone.
 

--- a/src/posts/wearethecity-shortlist-2016-entrepreneur-category.md
+++ b/src/posts/wearethecity-shortlist-2016-entrepreneur-category.md
@@ -16,9 +16,7 @@ It’s been another exciting start to the week. I’ve been shortlisted as co-fo
 
 The WATC Rising Star Awards are the first to focus on the UK’s female talent pipeline below management level and celebrates 100 individual female contributors representing the leaders and role models of tomorrow.
 
-<p class="pullquote">
-The awards are now in their second term and with over 950 nominations spanning across the UK and Northern Ireland, the number of entries received are treble that of last year.
-</p>
+The awards are now in their second term and with over 950 nominations spanning across the UK and Northern Ireland, the number of entries received are treble that of last year. {.pullquote}
 
 I’m really looking forward to attending the shortlisted celebration event sponsored by Bloomberg on the 17 May 2016. To have come this far since founding TreatOut in September is breathtaking. I feel both humbled and inspired to be listed amongst such a wealth of talented women.
 

--- a/src/scss/post.scss
+++ b/src/scss/post.scss
@@ -8,6 +8,13 @@ $outputTokenCSS: false;
 
 .post {
   padding-bottom: get-size('major');
+
+  dt {
+    border-bottom: 2px solid get-color('secondary');
+    font-size: get-size('500');
+    font-weight: bold;
+  }
+
   h2 {
     @include apply-utility('font', 'header');
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -1870,6 +1875,11 @@ entities@^2.0.0, entities@~2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+
+entities@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.1.0.tgz#992d3129cf7df6870b96c57858c249a120f8b8b5"
+  integrity sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
 
 errno@^0.1.2:
   version "0.1.7"
@@ -3791,6 +3801,13 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
+linkify-it@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
+  integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
+  dependencies:
+    uc.micro "^1.0.1"
+
 liquidjs@^6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/liquidjs/-/liquidjs-6.4.3.tgz#c7caf7a3f6c87dc6a22a5a351328cf8f7298c243"
@@ -3939,6 +3956,16 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it-attrs@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-it-attrs/-/markdown-it-attrs-3.0.3.tgz#92acdb16fe551cb056c5eb9848413443cafb5231"
+  integrity sha512-cLnICU2t61skNCr4Wih/sdza+UbQcqJGZwvqAypnbWA284nzDm+Gpc90iaRk/JjsIy4emag5v3s0rXFhFBWhCA==
+
+markdown-it-deflist@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-deflist/-/markdown-it-deflist-2.1.0.tgz#50d7a56b9544cd81252f7623bd785e28a8dcef5c"
+  integrity sha512-3OuqoRUlSxJiuQYu0cWTLHNhhq2xtoSFqsZK8plANg91+RJQU1ziQ6lA2LzmFAEes18uPBsHZpcX6We5l76Nzg==
+
 markdown-it@^10.0.0:
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
@@ -3947,6 +3974,17 @@ markdown-it@^10.0.0:
     argparse "^1.0.7"
     entities "~2.0.0"
     linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+markdown-it@^12.0.4:
+  version "12.0.4"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-12.0.4.tgz#eec8247d296327eac3ba9746bdeec9cfcc751e33"
+  integrity sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~2.1.0"
+    linkify-it "^3.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 


### PR DESCRIPTION
2 plugins have been added to extend markdown capabilities to make blog post writing easier in markdown.

## [markdown-it-attr]()
Ids, classes and aria attributes can now be added in markdown by appending `{ }`to the end of a block eg.
```
a paragraph with custom attributes{#id .custom-class aria-hidden=true}

// output
<p id="id" class="custom-class" aria-hidden="true">a paragraph with custom attributes</p>
```
The plugin recommends creating a whitelist for security. Although it shouldn't be
an issue, I've created one to only allow ids, classes and attributes staring with `aria`.

## [markdown-it-deflist](https://github.com/markdown-it/markdown-it-deflist)
can create description (definition) lists in markdown
```
This will be the dt text
: this will be the dd text

// output
<dl>
  <dt>This will be the dt text</dt>
  <dd>this will be the dd text</dd>
</dl>
```