### PR TITLE
Add visual dividers to blog layout

### DIFF
--- a/src/_includes/layouts/blog.html
+++ b/src/_includes/layouts/blog.html
@@ -23,82 +23,76 @@
       </section>
       <img class="latest__image" src="{{ latest.data.featureImage }}" alt="" />
 
-      {# divider utlility vertical #}
+      <hr class="divider divider--vertical">
+
       {% set levelPosts =  collections['level up'] %}
       {% if levelPosts %}
-        <div class="[ category ] [ panel ]">
-          <h2>Level Up</h2>
-          <ul class="flow flow-space-400">
-            {% for post in levelPosts %}
-                <li class="flow">
-                  <a href="{{ post.url }}">
-                    <h3>{{ post.data.title }}</h3>
-                  </a>
-                  <time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
-                  {% set tags = post.data.tags %}
-                  <div class="flow-space-100">
-                    {% include "partials/tags.html" %}
-                  </div>
-                </li>
-            {% endfor %}
-          </ul>
-          {# divider utility horizontal #}
-        </div>
+        <h2 id="lup" class="cat-header">Level Up</h2>
+        <hr class="divider divider--right-col">
+        <ul class="flow flow-space-400" aria-labelledby="lup">
+          {% for post in levelPosts %}
+              <li class="flow divider-bottom">
+                <a href="{{ post.url }}">
+                  <h3>{{ post.data.title }}</h3>
+                </a>
+                <time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
+                {% set tags = post.data.tags %}
+                <div class="flow-space-100">
+                  {% include "partials/tags.html" %}
+                </div>
+              </li>
+          {% endfor %}
+        </ul>
       {% endif %}
 
       {% set startupPosts =  collections['startup'] %}
       {% if startupPosts %}
-        <div class="category">
-          <h2>Startup</h2>
-          <ul class="flow flow-space-400">
-            {% for post in startupPosts %}
-              <li class="flow">
-                <a href="{{ post.url }}">
-                  <h3>{{ post.data.title }}</h3>
-                </a>
-                <time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
-                {% set tags = post.data.tags %}
-                <div class="flow-space-100">
-                  {% include "partials/tags.html" %}
-                </div>
-              </li>
+        <h2 id="sup" class="cat-header">Startup</h2>
+        <hr class="divider divider--right-col">
+        <ul class="flow flow-space-400" aria-labelledby="sup">
+          {% for post in startupPosts %}
+            <li class="flow divider-bottom">
+              <a href="{{ post.url }}">
+                <h3>{{ post.data.title }}</h3>
+              </a>
+              <time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
+              {% set tags = post.data.tags %}
+              <div class="flow-space-100">
+                {% include "partials/tags.html" %}
+              </div>
+            </li>
 
-            {% endfor %}
-          </ul>
-          {# divider utility horizontal #}
-        </div>
+          {% endfor %}
+        </ul>
       {% endif %}
 
       {% set soapboxPosts =  collections['soapbox'] %}
       {% if soapboxPosts %}
-        <div class="[ category ] [ panel ]">
-          <h2>Soapbox</h2>
-          <ul class="flow flow-space-400">
-            {% for post in soapboxPosts %}
-              <li class="flow">
-                <a href="{{ post.url }}">
-                  <h3>{{ post.data.title }}</h3>
-                </a>
-                <time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
-                {% set tags = post.data.tags %}
-                <div class="flow-space-100">
-                  {% include "partials/tags.html" %}
-                </div>
-              </li>
-            {% endfor %}
-          </ul>
-          {# divider utility horizontal #}
-        </div>
-      {% endif %}
-
-      <aside>
-        <h2>Archives</h2>
-        <ul>
-          {% for tag in collections.tagList %}
-            <li>{{ collections[ tag ] | length }} {{ tag }}</li>
+        <h2 id="sbox" class="cat-header">Soapbox</h2>
+        <hr class="divider divider--right-col">
+        <ul class="flow flow-space-400" aria-labelledby="sbox">
+          {% for post in soapboxPosts %}
+            <li class="flow divider-bottom">
+              <a href="{{ post.url }}">
+                <h3>{{ post.data.title }}</h3>
+              </a>
+              <time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
+              {% set tags = post.data.tags %}
+              <div class="flow-space-100">
+                {% include "partials/tags.html" %}
+              </div>
+            </li>
           {% endfor %}
         </ul>
-      </aside>
+      {% endif %}
+
+      <h2 id="arc">Archives</h2>
+      <hr class="divider divider--left-col">
+      <ul class="list-archives" aria-labelledby="arc">
+        {% for tag in collections.tagList %}
+          <li class="divider-bottom">{{ collections[ tag ] | length }} {{ tag }}</li>
+        {% endfor %}
+      </ul>
     </div>
   </article>
 {% endblock %}

--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -25,6 +25,7 @@ $gorko-size-scale: (
 */
 $gorko-colors: (
  'dark': #241D20,
+ 'dark-tint': #666163,
  'light': #EAE7D9,
  'primary': #910a55,
  'secondary': #FE8B3C,

--- a/src/scss/blocks/_grid-12-col.scss
+++ b/src/scss/blocks/_grid-12-col.scss
@@ -10,9 +10,5 @@
     margin-left: 0;
     margin-right: 0;
     max-width: 100%;
-
-    > * {
-      grid-column: 2 / -2;
-    }
   }
 }

--- a/src/scss/blog.scss
+++ b/src/scss/blog.scss
@@ -7,19 +7,60 @@ $outputTokenCSS: false;
 @import 'blocks/tags';
 
 .blog {
-  aside {
+  .divider { // applied to <hr>
+    border: none;
+    height: 1px;
+    margin: 0;
+    background-color: get-color('dark-tint');
+  }
+
+  .divider-bottom { // applied to <li>
+    border-bottom: solid 1px get-color('dark-tint');
+  }
+
+  .divider--vertical {
+    width: 1px;
+    height: 100%;
+  }
+
+  #arc {
     grid-column: 2 / span 3;
-    grid-row-start: 3;
+    grid-row-start: 5;
+  }
+
+  ul {
+    grid-column: 6 / -2;
+  }
+
+  .cat-header {
+    grid-column: 6 / -1;
+  }
+
+  .divider--left-col {
+    grid-column: 1 / span 4;
+    grid-row-start: 6;
+  }
+
+  .divider--right-col {
+    grid-column: 6 / -1;
+  }
+
+  .divider--vertical {
+    grid-column-start: 5;
+    grid-row: 2 / span 6;
   }
 
   .latest {
     grid-column: 2 / span 3;
-    grid-row: span 2;
+    grid-row: span 4;
   }
 
-  .latest__image,
-  .category {
+  .latest__image {
     grid-column: 5 / -2;
   }
-}
 
+  .list-archives {
+    grid-column: 2 / span 3;
+    grid-row-start: 7;
+  }
+}

--- a/src/scss/post.scss
+++ b/src/scss/post.scss
@@ -93,3 +93,9 @@ $outputTokenCSS: false;
     }
   }
 }
+
+@include media-query('md') {
+  .grid-12-col > * {
+    grid-column: 2 / -2;
+  }
+}


### PR DESCRIPTION
This adds visual dividers to the blog layout. Originally intended to create a utility class for this, but as not reused elsewhere, have instead opted to include styling of the dividers in the page critical css.