### PR TITLE
Create tags layout

### DIFF
--- a/gulp-tasks/sass.js
+++ b/gulp-tasks/sass.js
@@ -9,7 +9,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 
 // An array of outputs that should be sent over to includes
 // eg. const criticalStyles = ['critical.scss', 'home.scss', 'page.scss', 'work-item.scss'];
-const criticalStyles = ['blog.scss', 'critical.scss', 'cv.scss', 'home.scss', 'post.scss' ];
+const criticalStyles = ['blog.scss', 'critical.scss', 'cv.scss', 'home.scss', 'post.scss', 'tag.scss'];
 
 // Takes the arguments passed by `dest` and determines where the output file goes
 const calculateOutput = ({history}) => {

--- a/src/_data/helpers.js
+++ b/src/_data/helpers.js
@@ -21,6 +21,26 @@ module.exports = {
     return response;
   },
 
+   /**
+   * Filters out item (usually latest post) from the passed collection
+   * and limits number of items returned based on flag
+   *
+   * @param {Array} collection The 11ty collection
+   * @param {Object} item The item to exclude
+   * @param {Number} limit How many items to return. Default of zero does not apply a limit.
+   * @returns {Array} The resulting collection
+   */
+  getSiblingContent(collection, item, limit = 0) {
+    if (!collection) return null;
+    let filteredItems = collection.filter(x => x.date !== item.date);
+
+    if (limit > 0) {
+      filteredItems = filteredItems.slice(0, limit);
+    }
+
+    return filteredItems;
+  },
+
   getYear() {
     return new Date().getFullYear();
   }

--- a/src/_includes/layouts/blog.html
+++ b/src/_includes/layouts/blog.html
@@ -27,13 +27,16 @@
 
       <hr class="divider divider--vertical">
 
-      {% set collectionType = 'level up' %}
+      {% set tag = 'level up' %}
+      {% set posts = helpers.getSiblingContent(collections[tag], latest, 5) %}
       {% include "partials/collections.html" %}
 
-      {% set collectionType = 'startup' %}
+      {% set tag = 'startup' %}
+      {% set posts = helpers.getSiblingContent(collections[tag], latest, 5) %}
       {% include "partials/collections.html" %}
 
-      {% set collectionType = 'soapbox' %}
+      {% set tag = 'soapbox' %}
+      {% set posts = helpers.getSiblingContent(collections[tag], latest, 5) %}
       {% include "partials/collections.html" %}
 
       <h2 id="arc">Archives</h2>

--- a/src/_includes/layouts/tag.html
+++ b/src/_includes/layouts/tag.html
@@ -1,5 +1,31 @@
 {% extends "layouts/base.html" %}
+{% set pattern = "dark" %}
+{% set title = 'Tag: ' + tag | slug %}
+
+{% set pageCriticalStyles = ['css/blog.css', 'css/tag.css'] %}
 
 {% block content %}
-  <p>{{ tag }} tag page</p>
+  <article class="blog">
+    {% include "partials/page-title.html" %}
+    <div class="[ grid-12-col ] [ panel wrapper ] [ panel-space-major ]">
+      <div class="tag-archives">
+        <h2 id="arc">Archives</h2>
+        <hr class="divider divider--left-col">
+        <ul class="list-archives" aria-labelledby="arc">
+          {% for tag in collections.tagList %}
+            <li class="[ divider-bottom ] [ panel ] [ panel-space-100 ]">
+              <a href="/tag/{{ tag | slug }}/">
+                <span class="number--secondary">{{ collections[ tag ] | length }}</span><span class="tag">{{ tag }}<span>
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+
+      {% set posts = collections[ tag ] %}
+      <div class="[ tag-posts ] [ flow ]">
+        {% include "partials/collections.html" %}
+      </div>
+    </div>
+  </article>
 {% endblock %}

--- a/src/_includes/layouts/tag.html
+++ b/src/_includes/layouts/tag.html
@@ -1,6 +1,7 @@
 {% extends "layouts/base.html" %}
 {% set pattern = "dark" %}
 {% set title = 'Tag: ' + tag | slug %}
+{% set metaDesc = "Browse posts filed under the '" + tag | slug + "' tag from the SheCodes blog." %}
 
 {% set pageCriticalStyles = ['css/blog.css', 'css/tag.css'] %}
 

--- a/src/_includes/layouts/tag.html
+++ b/src/_includes/layouts/tag.html
@@ -1,0 +1,5 @@
+{% extends "layouts/base.html" %}
+
+{% block content %}
+  <p>{{ tag }} tag page</p>
+{% endblock %}

--- a/src/_includes/partials/collections.html
+++ b/src/_includes/partials/collections.html
@@ -1,25 +1,22 @@
-      {% set posts = collections[collectionType] %}
-      {% set collectionHash = global.random() %}
+{% if posts %}
+  {% set tagHash = global.random() %}
 
-      {% if posts.length > 0 %}
-        <h2 id="posts-{{ collectionHash }}" class="cat-header">{{ collectionType }}</h2>
-        <hr class="divider divider--right-col">
-        <ol class="[ flow ] [ flow-space-400 ]" aria-labelledby="posts-{{ collectionHash }}">
-          {% for post in posts | reverse %}
-            {% if loop.index < 6 %}
-              <li class="[ divider-bottom ] [ flow ]">
-                <div>
-                  <a href="{{ post.url }}">
-                    <h3>{{ post.data.title }}</h3>
-                  </a>
-                  <time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
-                  {% set tags = post.data.tags %}
-                  <div class="[ tags-wrapper ] [ flow-space-100 ]">
-                    {% include "partials/tags.html" %}
-                  </div>
-                <div>
-              </li>
-            {% endif %}
-          {% endfor %}
-        </ol>
-      {% endif %}
+  <h2 id="posts-{{ tagHash }}" class="cat-header">{{ tag }}</h2>
+  <hr class="divider divider--right-col">
+  <ol class="[ flow ] [ flow-space-400 ]" aria-labelledby="posts-{{ tagHash }}">
+    {% for post in posts | reverse %}
+      <li class="[ divider-bottom ] [ flow ]">
+        <div>
+          <a href="{{ post.url }}">
+            <h3>{{ post.data.title }}</h3>
+          </a>
+          <time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
+          {% set tags = post.data.tags %}
+          <div class="[ tags-wrapper ] [ flow-space-100 ]">
+            {% include "partials/tags.html" %}
+          </div>
+        <div>
+      </li>
+    {% endfor %}
+  </ol>
+{% endif %}

--- a/src/_includes/partials/collections.html
+++ b/src/_includes/partials/collections.html
@@ -1,11 +1,12 @@
       {% set posts = collections[collectionType] %}
       {% set collectionHash = global.random() %}
 
-      {% if posts %}
+      {% if posts.length > 0 %}
         <h2 id="posts-{{ collectionHash }}" class="cat-header">{{ collectionType }}</h2>
         <hr class="divider divider--right-col">
         <ol class="[ flow ] [ flow-space-400 ]" aria-labelledby="posts-{{ collectionHash }}">
-          {% for post in posts %}
+          {% for post in posts | reverse %}
+            {% if loop.index < 6 %}
               <li class="[ divider-bottom ] [ flow ]">
                 <div>
                   <a href="{{ post.url }}">
@@ -18,6 +19,7 @@
                   </div>
                 <div>
               </li>
+            {% endif %}
           {% endfor %}
         </ol>
       {% endif %}

--- a/src/blog.md
+++ b/src/blog.md
@@ -2,12 +2,5 @@
 title: 'She codes, she blogs'
 layout: 'layouts/blog.html'
 metaDesc: Daily struggles as a front end engineer, endless notes on trying to keep up with tech and the occasional soapbox rant.
-pagination:
-  data: collections.blog
-  size: 5
-permalink: 'blog{% if pagination.pageNumber > 0 %}/page/{{ pagination.pageNumber }}{% endif %}/index.html'
-paginationPrevText: 'Newer posts'
-paginationNextText: 'Older posts'
-paginationAnchor: '#post-list'
 ---
 

--- a/src/scss/tag.scss
+++ b/src/scss/tag.scss
@@ -1,0 +1,7 @@
+.tag-archives {
+  grid-column: 2/ span 3;
+}
+
+.tag-posts {
+  grid-column: 6/ -2;
+}

--- a/src/tag.md
+++ b/src/tag.md
@@ -1,5 +1,5 @@
 ---
-title: 'She blogs, she tags'
+title: {{ tag }}
 layout: 'layouts/tag.html'
 metaDesc: Browse the tags archive from the SheCodes blog.
 pagination:
@@ -7,4 +7,5 @@ pagination:
   size: 1
   alias: tag
 permalink: '/tag/{{ tag | slug }}/'
+pageHeaderTitle: '{{ tag }}'
 ---

--- a/src/tag.md
+++ b/src/tag.md
@@ -1,0 +1,10 @@
+---
+title: 'She blogs, she tags'
+layout: 'layouts/tag.html'
+metaDesc: Browse the tags archive from the SheCodes blog.
+pagination:
+  data: collections.tagList
+  size: 1
+  alias: tag
+permalink: '/tag/{{ tag | slug }}/'
+---

--- a/src/tag.md
+++ b/src/tag.md
@@ -1,11 +1,9 @@
 ---
 title: {{ tag }}
 layout: 'layouts/tag.html'
-metaDesc: Browse the tags archive from the SheCodes blog.
 pagination:
   data: collections.tagList
   size: 1
   alias: tag
 permalink: '/tag/{{ tag | slug }}/'
-pageHeaderTitle: '{{ tag }}'
 ---


### PR DESCRIPTION
This adds a layout for navigating blogposts by `tag`.

The `blog` page implementation of the `collections` partial is updated to exclude the latest post and limit total number of posts displayed under the three main tags, to a max of 5.

The `collections` partial is kept generic to allow reuse across tag and blog pages.