### PR TITLE
Remove array reverse() on collection arrays

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -25,23 +25,23 @@ module.exports = (config) => {
 	}
 
 	config.addCollection('cv_awards', (collection) => {
-		return collection.getFilteredByGlob('./src/awards/*.md').reverse();
+		return collection.getFilteredByGlob('./src/awards/*.md');
 	});
 
 	config.addCollection('blog', (collection) => {
-		return [...collection.getFilteredByGlob('./src/posts/**/*.md')].reverse();
+		return [...collection.getFilteredByGlob('./src/posts/**/*.md')];
 	});
 
 	config.addCollection('cv_education', (collection) => {
-		return collection.getFilteredByGlob('./src/education/*.md').reverse();
+		return collection.getFilteredByGlob('./src/education/*.md');
 	});
 
 	config.addCollection('cv_jobs', (collection) => {
-		return collection.getFilteredByGlob('./src/jobs/*.md').reverse();
+		return collection.getFilteredByGlob('./src/jobs/*.md');
 	});
 
 	config.addCollection('cv_talks', (collection) => {
-		return collection.getFilteredByGlob('./src/talks/*.md').reverse();
+		return collection.getFilteredByGlob('./src/talks/*.md');
 	});
 
 	config.addCollection('tagList', (collection) => {

--- a/src/_includes/layouts/blog.njk
+++ b/src/_includes/layouts/blog.njk
@@ -12,7 +12,7 @@
 		{% include "partials/page-title.njk" %}
 		<div class="[ grid-12-col ] [ flow wrapper ] [ flow-space-400 ]">
 
-			{% set latest = collections.blog[0] %}
+			{% set latest = collections.blog.slice(-1).pop() %}
 			<section class="[ latest ] [ flow panel ]">
 				<header>
 					<span class="number--primary outline" aria-label="latest post number">

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -35,7 +35,7 @@
 			<section class="flow flow-space-400">
 				<h2 id="work-ex"><span class="bullseye solid"></span>Work Experience</h2>
 				<dl aria-labelledby="work-ex" class="flow">
-					{% for job in collections.cv_jobs %}
+					{% for job in collections.cv_jobs | reverse %}
 						<dt class="term--primary">
 							<span class="bullseye outline"></span>{{ job.data.name}}
 						</dt>
@@ -57,7 +57,7 @@
 			<section class="flow flow-space-400">
 				<h2 id="education"><span class="bullseye solid"></span>Education</h2>
 				<dl aria-labelledby="education" class="flow">
-					{% for course in collections.cv_education %}
+					{% for course in collections.cv_education | reverse %}
 						<dt class="term--primary">
 							<span class="bullseye outline"></span>{{ course.data.course}}
 						</dt>
@@ -77,7 +77,7 @@
 			<section class="flow flow-space-400">
 				<h2 id="talks"><span class="bullseye solid"></span>Talks</h2>
 				<dl aria-labelledby="talks" class="flow">
-					{% for talk in collections.cv_talks %}
+					{% for talk in collections.cv_talks | reverse %}
 						<dt class="term--primary">
 							<span class="bullseye outline"></span>
 							{% if talk.data.link %}
@@ -106,7 +106,7 @@
 					<span class="bullseye solid"></span>Honours and Awards
 				</h2>
 				<dl aria-labelledby="awards" class="flow">
-					{% for award in collections.cv_awards %}
+					{% for award in collections.cv_awards | reverse %}
 						<dt class="term--primary">
 							<span class="bullseye outline"></span>{{ award.data.award}}
 						</dt>


### PR DESCRIPTION
This removes `reverse()` applied direct to the collections and instead uses the nunjucks utility to reverse sort collections.

This is [recommended best practice](https://www.11ty.dev/docs/collections/#array-reverse).