### PR TITLE
CSS refactoring

### DIFF
--- a/src/_includes/layouts/blog.njk
+++ b/src/_includes/layouts/blog.njk
@@ -60,7 +60,7 @@
 			<hr class="divider" />
 			<ul class="list-archives" aria-labelledby="arc">
 				{% for tag in collections.tagList %}
-					<li class="[ divider-bottom ] [ panel ] [ panel-space-100 ]">
+					<li class="[ divider-bottom ] [ panel ] [ panel-space-14 ]">
 						<a href="/tag/{{ tag | slug }}/">
 							<span class="number--secondary">{{ collections[ tag ] | length }}</span>
 							<span class="tag">{{ tag }}</span>

--- a/src/_includes/layouts/blog.njk
+++ b/src/_includes/layouts/blog.njk
@@ -16,7 +16,7 @@
 			<article class="[ latest ] [ flow ]">
 				<div class="[ article__meta ] [ flow ]">
 					<div>
-						<span class="number--primary outline" aria-label="blogpost number">
+						<span class="[ number--primary outline ]" aria-label="blogpost number">
 							{{ collections.blog | length }}
 						</span>
 						<h2 id="section-heading">Latest</h2>

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -9,35 +9,35 @@
 	<article>
 		{% include "partials/page-title.njk" %}
 		<div class="[ cv__timeline ] [ wrapper ]">
-			<section class="flow flow-space-20">
+			<section class="[ flow ] [ flow-space-20 ]">
 				<h2 id="skill"><span class="bullseye solid"></span>Expertise</h2>
-				<ul aria-labelledby="skill" class="flow flow-space-20">
+				<ul aria-labelledby="skill" class="[ flow ] [ flow-space-20 ]">
 					{% for skill in skills %}
-						<li><span class="bullseye outline"></span>{{ skill }}</li>
+						<li><span class="[ bullseye outline ]"></span>{{ skill }}</li>
 					{% endfor %}
 				</ul>
 
-				<h2 id="language"><span class="bullseye solid"></span>Languages</h2>
-				<ul aria-labelledby="language" class="flow flow-space-20">
+				<h2 id="language"><span class="[ bullseye solid ]"></span>Languages</h2>
+				<ul aria-labelledby="language" class="[ flow ] [ flow-space-20 ]">
 					{% for language in languages %}
-						<li><span class="bullseye outline"></span>{{ language }}</li>
+						<li><span class="[ bullseye outline ]"></span>{{ language }}</li>
 					{% endfor %}
 				</ul>
 
-				<h2 id="framework"><span class="bullseye solid"></span>Frameworks</h2>
-				<ul aria-labelledby="framework" class="flow flow-space-20">
+				<h2 id="framework"><span class="[ bullseye solid ]"></span>Frameworks</h2>
+				<ul aria-labelledby="framework" class="[ flow ] [ flow-space-20 ]">
 					{% for framework in frameworks %}
-						<li><span class="bullseye outline"></span>{{ framework }}</li>
+						<li><span class="[ bullseye outline ]"></span>{{ framework }}</li>
 					{% endfor %}
 				</ul>
 			</section>
 
-			<section class="flow flow-space-20">
-				<h2 id="work-ex"><span class="bullseye solid"></span>Work Experience</h2>
+			<section class="[ flow ] [ flow-space-20 ]">
+				<h2 id="work-ex"><span class="[ bullseye solid ]"></span>Work Experience</h2>
 				<dl aria-labelledby="work-ex" class="flow">
 					{% for job in collections.cv_jobs | reverse %}
 						<dt class="term--primary">
-							<span class="bullseye outline"></span>{{ job.data.name}}
+							<span class="[ bullseye outline ]"></span>{{ job.data.name}}
 						</dt>
 						<dt class="term--meta">
 							<div>
@@ -48,18 +48,18 @@
 						</dt>
 
 						{% for deliverable in job.data.deliverables%}
-							<dd><span class="bullseye bullet"></span>{{ deliverable }}</dd>
+							<dd><span class="[ bullseye bullet ]"></span>{{ deliverable }}</dd>
 						{% endfor %}
 					{% endfor %}
 				</dl>
 			</section>
 
-			<section class="flow flow-space-20">
-				<h2 id="education"><span class="bullseye solid"></span>Education</h2>
+			<section class="[ flow ] [ flow-space-20 ]">
+				<h2 id="education"><span class="[ bullseye solid ]"></span>Education</h2>
 				<dl aria-labelledby="education" class="flow">
 					{% for course in collections.cv_education | reverse %}
 						<dt class="term--primary">
-							<span class="bullseye outline"></span>{{ course.data.course}}
+							<span class="[ bullseye outline ]"></span>{{ course.data.course}}
 						</dt>
 						<dt class="term--meta">
 							<div>
@@ -68,18 +68,18 @@
 							</div>
 						</dt>
 						<dd>
-							<span class="bullseye bullet"></span>{{ course.templateContent | safe }}
+							<span class="[ bullseye bullet ]"></span>{{ course.templateContent | safe }}
 						</dd>
 					{% endfor %}
 				</dl>
 			</section>
 
-			<section class="flow flow-space-20">
-				<h2 id="talks"><span class="bullseye solid"></span>Talks</h2>
+			<section class="[ flow ] [ flow-space-20 ]">
+				<h2 id="talks"><span class="[ bullseye solid ]"></span>Talks</h2>
 				<dl aria-labelledby="talks" class="flow">
 					{% for talk in collections.cv_talks | reverse %}
 						<dt class="term--primary">
-							<span class="bullseye outline"></span>
+							<span class="[ bullseye outline ]"></span>
 							{% if talk.data.link %}
 								<a href="{{ talk.data.link}}">{{ talk.data.title}}</a>
 							{% else %}
@@ -92,8 +92,8 @@
 						</dt>
 
 						<dd>
-							<span class="bullseye bullet"></span>
-							<div class="flow flow-space-20">
+							<span class="[ bullseye bullet ]"></span>
+							<div class="[ flow ] [ flow-space-20 ]">
 								{{ talk.templateContent | safe }}
 							</div>
 						</dd>
@@ -101,17 +101,17 @@
 				</dl>
 			</section>
 
-			<section class="flow flow-space-20">
+			<section class="[ flow ] [ flow-space-20 ]">
 				<h2 id="awards">
-					<span class="bullseye solid"></span>Honours and Awards
+					<span class="[ bullseye solid ]"></span>Honours and Awards
 				</h2>
 				<dl aria-labelledby="awards" class="flow">
 					{% for award in collections.cv_awards | reverse %}
 						<dt class="term--primary">
-							<span class="bullseye outline"></span>{{ award.data.award}}
+							<span class="[ bullseye outline ]"></span>{{ award.data.award}}
 						</dt>
 						{% for detail in award.data.details%}
-							<dd><span class="bullseye bullet"></span>{{ detail }}</dd>
+							<dd><span class="[ bullseye bullet ]"></span>{{ detail }}</dd>
 						{% endfor %}
 					{% endfor %}
 				</dl>

--- a/src/_includes/layouts/cv.njk
+++ b/src/_includes/layouts/cv.njk
@@ -9,30 +9,30 @@
 	<article>
 		{% include "partials/page-title.njk" %}
 		<div class="[ cv__timeline ] [ wrapper ]">
-			<section class="flow flow-space-400">
+			<section class="flow flow-space-20">
 				<h2 id="skill"><span class="bullseye solid"></span>Expertise</h2>
-				<ul aria-labelledby="skill" class="flow flow-space-400">
+				<ul aria-labelledby="skill" class="flow flow-space-20">
 					{% for skill in skills %}
 						<li><span class="bullseye outline"></span>{{ skill }}</li>
 					{% endfor %}
 				</ul>
 
 				<h2 id="language"><span class="bullseye solid"></span>Languages</h2>
-				<ul aria-labelledby="language" class="flow flow-space-400">
+				<ul aria-labelledby="language" class="flow flow-space-20">
 					{% for language in languages %}
 						<li><span class="bullseye outline"></span>{{ language }}</li>
 					{% endfor %}
 				</ul>
 
 				<h2 id="framework"><span class="bullseye solid"></span>Frameworks</h2>
-				<ul aria-labelledby="framework" class="flow flow-space-400">
+				<ul aria-labelledby="framework" class="flow flow-space-20">
 					{% for framework in frameworks %}
 						<li><span class="bullseye outline"></span>{{ framework }}</li>
 					{% endfor %}
 				</ul>
 			</section>
 
-			<section class="flow flow-space-400">
+			<section class="flow flow-space-20">
 				<h2 id="work-ex"><span class="bullseye solid"></span>Work Experience</h2>
 				<dl aria-labelledby="work-ex" class="flow">
 					{% for job in collections.cv_jobs | reverse %}
@@ -54,7 +54,7 @@
 				</dl>
 			</section>
 
-			<section class="flow flow-space-400">
+			<section class="flow flow-space-20">
 				<h2 id="education"><span class="bullseye solid"></span>Education</h2>
 				<dl aria-labelledby="education" class="flow">
 					{% for course in collections.cv_education | reverse %}
@@ -74,7 +74,7 @@
 				</dl>
 			</section>
 
-			<section class="flow flow-space-400">
+			<section class="flow flow-space-20">
 				<h2 id="talks"><span class="bullseye solid"></span>Talks</h2>
 				<dl aria-labelledby="talks" class="flow">
 					{% for talk in collections.cv_talks | reverse %}
@@ -93,7 +93,7 @@
 
 						<dd>
 							<span class="bullseye bullet"></span>
-							<div class="flow flow-space-400">
+							<div class="flow flow-space-20">
 								{{ talk.templateContent | safe }}
 							</div>
 						</dd>
@@ -101,7 +101,7 @@
 				</dl>
 			</section>
 
-			<section class="flow flow-space-400">
+			<section class="flow flow-space-20">
 				<h2 id="awards">
 					<span class="bullseye solid"></span>Honours and Awards
 				</h2>

--- a/src/_includes/layouts/post.njk
+++ b/src/_includes/layouts/post.njk
@@ -13,7 +13,7 @@
 			<div class="wrapper">{% include "partials/tags.njk" %}</div>
 		</div>
 
-		<div class="post__content post__grid grid-12-col flow wrapper">
+		<div class="[ post__content post__grid ] [ grid-12-col ] [ flow wrapper ]">
 			{% if featureImage %}
 				{% imageShortcode featureImage, featureImageAlt, "feature", "(min-width: 62em) 612px, 100vw" %}
 			{% endif %}

--- a/src/_includes/layouts/tag.njk
+++ b/src/_includes/layouts/tag.njk
@@ -20,7 +20,7 @@
 				<hr class="divider" />
 				<ul class="list-archives" aria-labelledby="arc">
 					{% for tag in collections.tagList %}
-						<li class="[ divider-bottom ] [ panel ] [ panel-space-100 ]">
+						<li class="[ divider-bottom ] [ panel ] [ panel-space-14 ]">
 							<a href="/tag/{{ tag | slug }}/">
 								<span class="number--secondary">{{ collections[ tag ] | length }}</span>
 								<span class="tag">{{ tag }}</span>

--- a/src/_includes/partials/collections.njk
+++ b/src/_includes/partials/collections.njk
@@ -4,7 +4,7 @@
 	<section class="[ collection ] [ panel ]">
 		<h2 id="posts-{{ tagHash }}" class="cat-header">{{ tag }}</h2>
 		<hr class="divider" />
-		<ol class="[ flow ] [ flow-space-400 ]" aria-labelledby="posts-{{ tagHash }}">
+		<ol class="[ flow ] [ flow-space-20 ]" aria-labelledby="posts-{{ tagHash }}">
 			{% for post in posts | reverse %}
 				<li class="[ divider-bottom ] [ flow ]">
 					<article>
@@ -14,7 +14,7 @@
 						<time datetime="{{ post.data.date }}">{{ post.data.date | dateFilter("full") }}</time>
 
 						{% set tags = post.data.tags %}
-						<div class="[ tags-wrapper ] [ flow-space-100 ]">
+						<div class="[ tags-wrapper ] [ flow-space-14 ]">
 							{% include "partials/tags.njk" %}
 						</div>
 					</article>

--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -2,7 +2,7 @@
 	{% set pattern = "light" %}
 {% endif %}
 
-<a class="[ skip-link ] [ button ]" href="#main-content">Skip to content</a>
+<a class="skip-link" href="#main-content">Skip to content</a>
 <header class="[ site-header ] [ panel patterned-{{ pattern }} a11y-bg-{{ headerCol }} ]">
 	<div class="wrapper">
 		<nav class="nav" aria-label="Primary">

--- a/src/scss/_config.scss
+++ b/src/scss/_config.scss
@@ -1,23 +1,22 @@
 $gorko-base-size: 1rem;
 
 /**
-* SIZE SCALE - [Major second scale](https://www.modularscale.com/?62.5&%&1.2)
-* powers all relevant utilities (font-size, margin, padding).
+* Powers all relevant utilities (font-size, margin, padding).
 * All items calculated off base size
 */
 $gorko-size-scale: (
 	'minor': $gorko-base-size * 0.5,
 	'base': $gorko-base-size,
-	'100': $gorko-base-size * 1.424,
-	'200': $gorko-base-size * 1.602,
-	'300': $gorko-base-size * 1.802,
-	'400': $gorko-base-size * 2.027,
-	'500': $gorko-base-size * 2.281,
-	'600': $gorko-base-size * 2.566,
-	'700': $gorko-base-size * 2.887,
-	'800': $gorko-base-size * 3.247,
-	'900': $gorko-base-size * 3.653,
-	'major': $gorko-base-size * 4.11,
+	'14': $gorko-base-size * 1.4,
+	'16': $gorko-base-size * 1.6,
+	'18': $gorko-base-size * 1.8,
+	'20': $gorko-base-size * 2,
+	'22': $gorko-base-size * 2.2,
+	'25': $gorko-base-size * 2.5,
+	'28': $gorko-base-size * 2.8,
+	'32': $gorko-base-size * 3.2,
+	'36': $gorko-base-size * 3.6,
+	'major': $gorko-base-size * 4.2,
 );
 
 /**
@@ -64,11 +63,6 @@ $gorko-config: (
 		'items': $gorko-size-scale,
 		'output': 'responsive',
 		'property': '--panel-space',
-	),
-	'spacing-top': (
-		'items': $gorko-size-scale,
-		'output': 'responsive',
-		'property': 'margin-top',
 	),
 	'text': (
 		'items': $gorko-size-scale,

--- a/src/scss/blocks/_footer.scss
+++ b/src/scss/blocks/_footer.scss
@@ -1,4 +1,4 @@
 footer {
 	flex-shrink: 0;
-	font-size: get-size('400');
+	font-size: get-size('20');
 }

--- a/src/scss/blocks/_grid-12-col.scss
+++ b/src/scss/blocks/_grid-12-col.scss
@@ -1,10 +1,10 @@
 @include media-query('md') {
 	.grid-12-col {
-		--inner-grid-gaps: calc(#{get-size('500')} * 11);
+		--inner-grid-gaps: calc(#{get-size('22')} * 11);
 		--inner-col-width: calc((var(--layout-width) - var(--inner-grid-gaps)) / 10);
 
 		display: grid;
-		grid-gap: 0 get-size('500');
+		grid-gap: 0 get-size('22');
 		grid-template-columns:
 			minmax(0, 1fr) repeat(10, minmax(0, var(--inner-col-width)))
 			minmax(0, 1fr);

--- a/src/scss/blocks/_logo.scss
+++ b/src/scss/blocks/_logo.scss
@@ -1,7 +1,7 @@
 .logo {
 	fill: get-color('light');
-	padding-bottom: get-size('700');
-	padding-top: get-size('700');
+	padding-bottom: get-size('28');
+	padding-top: get-size('28');
 
 	.o {
 		fill: get-color('secondary');

--- a/src/scss/blocks/_nav.scss
+++ b/src/scss/blocks/_nav.scss
@@ -7,8 +7,8 @@
 	flex-wrap: wrap;
 
 	> li {
-		padding-bottom: get-size('300');
-		padding-right: get-size('600');
+		padding-bottom: get-size('18');
+		padding-right: get-size('25');
 	}
 
 	a {

--- a/src/scss/blocks/_skip-link.scss
+++ b/src/scss/blocks/_skip-link.scss
@@ -4,13 +4,13 @@
 	background-color: get-color('light');
 	border: 4px solid get-color('secondary');
 	color: get-color('dark');
-	left: get-size('300');
+	left: get-size('18');
 	outline: 2px dotted get-color('light');
 	outline-offset: 5px;
-	padding: get-size('200') get-size('300');
+	padding: get-size('16') get-size('18');
 	position: absolute;
 	text-decoration: none;
-	top: get-size('300');
+	top: get-size('18');
 	z-index: 100;
 
 	&:not(:focus) {

--- a/src/scss/blocks/_tags.scss
+++ b/src/scss/blocks/_tags.scss
@@ -1,7 +1,7 @@
 .list--tags {
 	display: flex;
 	flex-wrap: wrap;
-	font-size: get-size('100');
+	font-size: get-size('14');
 	margin-inline-start: -#{get-size('base')};
 	text-transform: uppercase;
 

--- a/src/scss/blog.scss
+++ b/src/scss/blog.scss
@@ -100,11 +100,6 @@ $outputTokenCSS: false;
 		margin-right: 0;
 	}
 
-	.divider-bottom {
-		// applied to <li>
-		border-bottom: solid 1px get-color('dark-tint');
-	}
-
 	.grid-12-col {
 		padding-bottom: get-size('major');
 	}

--- a/src/scss/blog.scss
+++ b/src/scss/blog.scss
@@ -23,13 +23,13 @@ $outputTokenCSS: false;
 
 		.article__content {
 			margin-top: 0;
-			padding-left: get-size('100');
+			padding-left: get-size('14');
 			width: 60%;
 		}
 
 		.collection {
 			float: right;
-			padding-left: get-size('100');
+			padding-left: get-size('14');
 			width: 60%;
 		}
 	}
@@ -49,7 +49,7 @@ $outputTokenCSS: false;
 	}
 
 	time {
-		font-size: get-size('200');
+		font-size: get-size('16');
 	}
 
 	ol {
@@ -75,12 +75,12 @@ $outputTokenCSS: false;
 			counter-increment: post-counter;
 			display: flex;
 			flex-shrink: 0;
-			font-size: get-size('600');
+			font-size: get-size('25');
 			font-style: italic;
 			height: 6rem;
 			justify-content: center;
 			letter-spacing: 0.35rem;
-			margin-right: get-size('200');
+			margin-right: get-size('16');
 			padding: get-size('minor');
 			width: 6rem;
 		}
@@ -116,12 +116,12 @@ $outputTokenCSS: false;
 		}
 
 		span {
-			margin-right: get-size('200');
+			margin-right: get-size('16');
 		}
 	}
 
 	.latest__heading {
-		font-size: get-size('800');
+		font-size: get-size('32');
 	}
 
 	.latest__image {
@@ -143,7 +143,7 @@ $outputTokenCSS: false;
 
 		.tag {
 			flex: 1 0 auto;
-			padding-left: get-size('200');
+			padding-left: get-size('16');
 		}
 	}
 
@@ -163,7 +163,7 @@ $outputTokenCSS: false;
 		border-radius: 50%;
 		color: get-color('light');
 		display: inline-flex;
-		font-size: get-size('600');
+		font-size: get-size('25');
 		font-style: italic;
 		height: 6rem;
 		justify-content: center;
@@ -181,7 +181,7 @@ $outputTokenCSS: false;
 		background-color: get-color('secondary-tint');
 		border-radius: 50%;
 		display: flex;
-		font-size: get-size('600');
+		font-size: get-size('25');
 		font-style: italic;
 		height: 4rem;
 		justify-content: center;
@@ -190,7 +190,7 @@ $outputTokenCSS: false;
 	}
 
 	.tags-wrapper {
-		padding-bottom: get-size('800');
-		padding-top: get-size('400');
+		padding-bottom: get-size('32');
+		padding-top: get-size('20');
 	}
 }

--- a/src/scss/critical.scss
+++ b/src/scss/critical.scss
@@ -5,7 +5,7 @@
 
 // Global styles
 :root {
-	--flow-space: #{get-size('700')};
+	--flow-space: #{get-size('28')};
 	--layout-width: 92.8rem;
 
 	font-size: 62.5%;
@@ -23,7 +23,7 @@ body {
 	color: get-color('dark');
 	display: flex;
 	flex-direction: column;
-	font-size: get-size('400');
+	font-size: get-size('20');
 	letter-spacing: 0.1px;
 	word-spacing: 0;
 }
@@ -42,7 +42,7 @@ a:not([class]) {
 h1 {
 	@include apply-utility('font', 'header');
 
-	font-size: get-size('700');
+	font-size: get-size('28');
 }
 
 h2,
@@ -84,7 +84,7 @@ p > a:focus {
 .fonts-loading {
 	body {
 		font-family: Arial, sans-serif;
-		font-size: get-size('400');
+		font-size: get-size('20');
 		letter-spacing: -1.6px;
 		line-height: 1.5;
 		word-spacing: -1.1px;
@@ -102,7 +102,7 @@ p > a:focus {
 
 	h1,
 	h2 {
-		font-size: get-size('800');
+		font-size: get-size('32');
 		letter-spacing: -0.5px;
 		word-spacing: 0.15px;
 	}

--- a/src/scss/critical.scss
+++ b/src/scss/critical.scss
@@ -116,6 +116,7 @@ p > a:focus {
 
 // Import utilities using @import 'utilities/<file-name>';
 @import 'utilities/colour-contrast';
+@import 'utilities/divider';
 @import 'utilities/flow';
 @import 'utilities/no-wrap';
 @import 'utilities/panel';

--- a/src/scss/cv.scss
+++ b/src/scss/cv.scss
@@ -5,7 +5,7 @@ $outputTokenCSS: false;
 
 dl,
 section {
-	padding-bottom: get-size('900');
+	padding-bottom: get-size('36');
 	position: relative;
 
 	&::before {
@@ -36,7 +36,7 @@ dt {
 		--flow-space: #{get-size('major')};
 		@include apply-utility('font', 'header');
 
-		font-size: get-size('500');
+		font-size: get-size('22');
 		font-weight: bold;
 
 		a:focus,
@@ -117,7 +117,7 @@ dd {
 h2 {
 	@include apply-utility('font', 'heavy');
 
-	font-size: get-size('600');
-	padding-bottom: get-size('400');
-	padding-top: get-size('900');
+	font-size: get-size('25');
+	padding-bottom: get-size('20');
+	padding-top: get-size('36');
 }

--- a/src/scss/post.scss
+++ b/src/scss/post.scss
@@ -61,7 +61,7 @@ $outputTokenCSS: false;
 
 	dt {
 		border-bottom: 2px solid get-color('secondary');
-		font-size: get-size('500');
+		font-size: get-size('22');
 		font-weight: bold;
 	}
 
@@ -85,7 +85,7 @@ $outputTokenCSS: false;
 	}
 
 	.feature {
-		margin-left: -#{get-size('500')};
+		margin-left: -#{get-size('22')};
 		margin-top: 0;
 		max-width: 100vw;
 	}
@@ -96,11 +96,11 @@ $outputTokenCSS: false;
 
 	.post__content ul {
 		list-style: none;
-		padding-left: get-size('800');
+		padding-left: get-size('32');
 	}
 
 	.post__content li {
-		margin-bottom: get-size('100');
+		margin-bottom: get-size('14');
 		position: relative;
 
 		&::before {
@@ -109,13 +109,13 @@ $outputTokenCSS: false;
 			border: 1px solid get-color('secondary');
 			border-radius: 50%;
 			content: '';
-			height: get-size('500');
-			left: -#{get-size('800')};
-			margin-right: get-size('200');
+			height: get-size('22');
+			left: -#{get-size('32')};
+			margin-right: get-size('16');
 			padding: 3px;
 			position: absolute;
 			top: get-size('minor');
-			width: get-size('500');
+			width: get-size('22');
 		}
 	}
 

--- a/src/scss/utilities/_divider.scss
+++ b/src/scss/utilities/_divider.scss
@@ -1,0 +1,4 @@
+.divider-bottom {
+	// applied to <li>
+	border-bottom: solid 1px get-color('dark-tint');
+}

--- a/src/scss/utilities/_flow.scss
+++ b/src/scss/utilities/_flow.scss
@@ -1,3 +1,3 @@
 .flow > * + * {
-	margin-top: var(--flow-space, get-size('600'));
+	margin-top: var(--flow-space, get-size('25'));
 }

--- a/src/scss/utilities/_panel.scss
+++ b/src/scss/utilities/_panel.scss
@@ -1,4 +1,4 @@
 .panel {
-	padding-bottom: var(--panel-space, get-size('700'));
-	padding-top: var(--panel-space, get-size('700'));
+	padding-bottom: var(--panel-space, get-size('28'));
+	padding-top: var(--panel-space, get-size('28'));
 }

--- a/src/scss/utilities/_wrapper.scss
+++ b/src/scss/utilities/_wrapper.scss
@@ -7,8 +7,8 @@
 	margin-left: auto;
 	margin-right: auto;
 	max-width: 60rem;
-	padding-left: get-size('500');
-	padding-right: get-size('500');
+	padding-left: get-size('22');
+	padding-right: get-size('22');
 	position: relative;
 }
 


### PR DESCRIPTION
Closes #25 

This PR refactors CSS  as follows:

## design tokens
Opted for a meaningful naming strategy over previous abstract `100` to `900` which was too high a cognitive load to work out what it meant. HTML font size is set to map 1:1 so 1rem = 10px. Sizing tokens now reflect the size. This should not be an issue as this is not expected to change.

## grouping consistency with square brackets
This idea is taken from the [CUBE methodology](https://piccalil.li/blog/cube-css#heading-grouping) whereby the square brackets denote main block classes, block classes, utility classes and design tokens.
