### PR TITLE
Refactor primary navigation

### DIFF
--- a/src/_includes/partials/header.njk
+++ b/src/_includes/partials/header.njk
@@ -2,7 +2,7 @@
 	{% set pattern = "light" %}
 {% endif %}
 
-<a class="skip-link" href="#main-content">Skip to content</a>
+<a class="skip-link {{ headerCol if headerCol === 'light' }}" href="#main-content">Skip to content</a>
 <header class="[ site-header ] [ panel patterned-{{ pattern }} a11y-bg-{{ headerCol }} ]">
 	<div class="wrapper">
 		<nav class="nav" aria-label="Primary">

--- a/src/scss/blocks/_nav.scss
+++ b/src/scss/blocks/_nav.scss
@@ -7,7 +7,6 @@
 	flex-wrap: wrap;
 
 	> li {
-		padding-bottom: get-size('18');
 		padding-right: get-size('25');
 	}
 

--- a/src/scss/blocks/_skip-link.scss
+++ b/src/scss/blocks/_skip-link.scss
@@ -5,13 +5,16 @@
 	border: 4px solid get-color('secondary');
 	color: get-color('dark');
 	left: get-size('18');
-	outline: 2px dotted get-color('light');
 	outline-offset: 5px;
 	padding: get-size('16') get-size('18');
 	position: absolute;
 	text-decoration: none;
 	top: get-size('18');
 	z-index: 100;
+
+	&.light {
+		--focus-color: #{get-color('dark')};
+	}
 
 	&:not(:focus) {
 		@extend .visually-hidden;

--- a/src/scss/blocks/_tags.scss
+++ b/src/scss/blocks/_tags.scss
@@ -2,11 +2,11 @@
 	display: flex;
 	flex-wrap: wrap;
 	font-size: get-size('14');
-	margin-inline-start: -#{get-size('base')};
+	margin-left: -#{get-size('base')};
 	text-transform: uppercase;
 
 	> * {
-		margin-inline-start: get-size('base');
+		margin-left: get-size('base');
 	}
 
 	a {


### PR DESCRIPTION
Closes #56 
 
Removes bottom padding to visually center in header. 
Skip link focus colour matches nav link dark outline when on light background.

![primary-nav-refactor](https://user-images.githubusercontent.com/5786823/113941087-69572580-97f6-11eb-814e-861263e8a129.jpeg)
