### PR TITLE
adds new date filter that can format eleventy page date

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 const dateFilter = require('./src/filters/date-filter.js');
+const isoDateFilter = require('./src/filters/isodate-filter.js');
 const imageShortcode = require('./src/shortcodes/image.js');
 const mdIt = require('markdown-it');
 const mdDeflist = require('markdown-it-deflist');
@@ -11,6 +12,7 @@ module.exports = (config) => {
 	config.addPassthroughCopy('./src/sitemap.xml');
 	// add filters
 	config.addFilter('dateFilter', dateFilter);
+	config.addFilter('isoDateFilter', isoDateFilter);
 
 	// Shortcodes
 	config.addNunjucksAsyncShortcode('imageShortcode', imageShortcode);

--- a/src/filters/isodate-filter.js
+++ b/src/filters/isodate-filter.js
@@ -1,0 +1,8 @@
+const format = require('date-fns/format');
+
+// parseISO() not needed as page date already in ISO format
+// Mon Mar 15 2021 00:33:23 GMT+0000 (Greenwich Mean Time)
+
+module.exports = (date) => {
+	return format(date, 'yyyy-MM-dd');
+};


### PR DESCRIPTION
This PR adds a new date filter to format eleventy's page.date (value is the page's modified date).

Closes #103 