### PR TITLE
fix: replace deprecated $outputTokenCSS

### DIFF
--- a/src/scss/blog.scss
+++ b/src/scss/blog.scss
@@ -1,6 +1,6 @@
 @import 'config';
 // Set Gorko to output no CSS for this file
-$outputTokenCSS: false;
+$generate-utility-classes: false;
 @import '../../node_modules/gorko/gorko';
 
 @import 'blocks/grid-12-col';

--- a/src/scss/cv.scss
+++ b/src/scss/cv.scss
@@ -1,6 +1,6 @@
 @import 'config';
 // Set Gorko to output no CSS for this file
-$outputTokenCSS: false;
+$generate-utility-classes: false;
 @import '../../node_modules/gorko/gorko';
 
 dl,

--- a/src/scss/home.scss
+++ b/src/scss/home.scss
@@ -1,6 +1,6 @@
 @import 'config';
 // Set Gorko to output no CSS for this file
-$outputTokenCSS: false;
+$generate-utility-classes: false;
 @import '../../node_modules/gorko/gorko';
 
 @import 'blocks/pullquote';

--- a/src/scss/post.scss
+++ b/src/scss/post.scss
@@ -1,6 +1,6 @@
 @import 'config';
 // Set Gorko to output no CSS for this file
-$outputTokenCSS: false;
+$generate-utility-classes: false;
 @import '../../node_modules/gorko/gorko';
 
 @import 'blocks/tags';


### PR DESCRIPTION
This fixes Gorko's deprecated key warning:
`gorko WARNING: $outputTokenCSS is deprecated. Please use $generate-utility-classes instead`