### PR TITLE
fix: switch arrow function to regular function as shown in docs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,4 @@
 const { parallel, watch } = require('gulp');
-
 // Pull in each task
 const sass = require('./gulp-tasks/sass.js');
 
@@ -7,11 +6,11 @@ const sass = require('./gulp-tasks/sass.js');
 // assign the relevant task. `ignoreInitial` set to true will
 // prevent the task being run when we run `gulp watch`, but it
 // will run when a file changes.
-const watcher = () => {
+function watcher() {
 	watch('./src/scss/**/*.scss', { ignoreInitial: true }, sass);
-};
+}
 
-// The default (if someone just runs `gulp`) is to run each task in parrallel
+// The default (if someone just runs `gulp`) is to run each task in parallel
 exports.default = parallel(sass);
 
 // This is our watcher task that instructs gulp to watch directories and


### PR DESCRIPTION
Starting server shows following error -

```
07:23:03] Using gulpfile ~/code/nccshecodes/shecodes-2020/gulpfile.js
[0] [07:23:03] Starting 'watch'...
[0] [07:23:03] The following tasks did not complete: watch
[0] [07:23:03] Did you forget to signal async completion?
[0] npx gulp watch exited with code 1
```
This means that css changes are not updated in the browser.

Switching from arrow function to regular function as shown in the [gulp docs](https://gulpjs.com/docs/en/api/parallel) clears the error and any css changes are instantly refreshed in the browser.


Closes #132 